### PR TITLE
[#76] 메뉴 생성시 image 데이터 전달받는 방식을 변경

### DIFF
--- a/src/main/java/com/tasty/masiottae/menu/controller/MenuController.java
+++ b/src/main/java/com/tasty/masiottae/menu/controller/MenuController.java
@@ -28,7 +28,7 @@ public class MenuController {
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<MenuSaveResponse> saveMenu(@RequestPart MenuSaveUpdateRequest data,
-            @RequestPart MultipartFile image) {
+            @RequestPart(required = false) MultipartFile image) {
         return new ResponseEntity<>(menuService.createMenu(data, image), HttpStatus.CREATED);
     }
 


### PR DESCRIPTION
## 개요
- 메뉴 생성시 요청에 image 키 값 자체가 없어도 정상 동작하도록 수정

## 변경사항(Optional)
- @RequiredPart required 옵션을 false로 변경