### PR TITLE
[#81] ExceptionHandler 오타 수정

### DIFF
--- a/src/main/java/com/tasty/masiottae/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/tasty/masiottae/common/exception/GlobalExceptionHandler.java
@@ -28,9 +28,9 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(NotFoundException.class)
     protected ResponseEntity<ErrorResponse> handleNotFoundException(
-            MethodArgumentNotValidException e) {
+            NotFoundException e) {
         final ErrorResponse response = ErrorResponse.of(e.getMessage(),
-                HttpServletResponse.SC_NOT_FOUND, e.getBindingResult());
+                HttpServletResponse.SC_NOT_FOUND);
         return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
     }
 }


### PR DESCRIPTION
## 개요
- NotFoundException 핸들러 오타 수정

## 변경사항(Optional)

### 변경 전
- NotFoundException 핸들러 파라미터에 MethodArgumentNotValidException 타입이 선언이 되어있음

### 변경 후
- 파라미터 타입을 NotFoundException으로 수정
