### PR TITLE
[#93] accountId -> userId로 필드명 변경

### DIFF
--- a/src/main/java/com/tasty/masiottae/comment/dto/CommentSaveRequest.java
+++ b/src/main/java/com/tasty/masiottae/comment/dto/CommentSaveRequest.java
@@ -3,7 +3,7 @@ package com.tasty.masiottae.comment.dto;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
-public record CommentSaveRequest(@NotNull(message = "유저의 Id는 필수입니다.") Long accountId,
+public record CommentSaveRequest(@NotNull(message = "유저의 Id는 필수입니다.") Long userId,
                                  @NotNull(message = "메뉴 Id는 필수입니다.") Long menuId,
                                  @NotBlank(message = "댓글 내용을 입력해주세요.") String content) {
 

--- a/src/main/java/com/tasty/masiottae/comment/service/CommentService.java
+++ b/src/main/java/com/tasty/masiottae/comment/service/CommentService.java
@@ -36,7 +36,7 @@ public class CommentService {
     public CommentSaveResponse createComment(CommentSaveRequest request) {
         Menu menu = menuRepository.findById(request.menuId())
             .orElseThrow(() -> new EntityNotFoundException(NOT_FOUND_MENU.getMessage()));
-        Account account = accountRepository.findById(request.accountId())
+        Account account = accountRepository.findById(request.userId())
             .orElseThrow(() -> new EntityNotFoundException(NOT_FOUND_ACCOUNT.getMessage()));
 
         checkContentIsNotEmpty(request);

--- a/src/test/java/com/tasty/masiottae/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/tasty/masiottae/comment/controller/CommentControllerTest.java
@@ -60,7 +60,7 @@ class CommentControllerTest {
         // given
         CommentSaveRequest request = new CommentSaveRequest(1L, 1L, "댓글내용");
         CommentSaveResponse response = new CommentSaveResponse(request.menuId(),
-            request.accountId());
+            request.userId());
         given(commentService.createComment(request)).willReturn(response);
 
         // expected
@@ -70,7 +70,7 @@ class CommentControllerTest {
             .andDo(print())
             .andDo(document("comment-save",
                 requestFields(
-                    fieldWithPath("accountId").type(JsonFieldType.NUMBER)
+                    fieldWithPath("userId").type(JsonFieldType.NUMBER)
                         .description("유저 ID"),
                     fieldWithPath("menuId").type(JsonFieldType.NUMBER)
                         .description("메뉴 ID"),
@@ -105,12 +105,18 @@ class CommentControllerTest {
                     fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("댓글 ID"),
                     fieldWithPath("[].menuId").type(JsonFieldType.NUMBER).description("메뉴 ID"),
                     fieldWithPath("[].author.id").type(JsonFieldType.NUMBER).description("유저 ID"),
-                    fieldWithPath("[].author.image").type(JsonFieldType.STRING).description("유저 프로필 이미지"),
-                    fieldWithPath("[].author.nickName").type(JsonFieldType.STRING).description("유저 닉네임"),
-                    fieldWithPath("[].author.email").type(JsonFieldType.STRING).description("유저 이메일"),
-                    fieldWithPath("[].author.snsAccount").type(JsonFieldType.STRING).description("SNS 계정"),
-                    fieldWithPath("[].author.createdAt").type(JsonFieldType.STRING).description("생성일"),
-                    fieldWithPath("[].author.menuCount").type(JsonFieldType.NUMBER).description("유저 생성 메뉴 개수"),
+                    fieldWithPath("[].author.image").type(JsonFieldType.STRING)
+                        .description("유저 프로필 이미지"),
+                    fieldWithPath("[].author.nickName").type(JsonFieldType.STRING)
+                        .description("유저 닉네임"),
+                    fieldWithPath("[].author.email").type(JsonFieldType.STRING)
+                        .description("유저 이메일"),
+                    fieldWithPath("[].author.snsAccount").type(JsonFieldType.STRING)
+                        .description("SNS 계정"),
+                    fieldWithPath("[].author.createdAt").type(JsonFieldType.STRING)
+                        .description("생성일"),
+                    fieldWithPath("[].author.menuCount").type(JsonFieldType.NUMBER)
+                        .description("유저 생성 메뉴 개수"),
                     fieldWithPath("[].comment").type(JsonFieldType.STRING).description("댓글 내용"))));
     }
 }


### PR DESCRIPTION
## 개요
- DTO 필드명 통일화


## 변경사항(Optional)
- 댓글 작성시 사용되는 DTO accountId -> userId로 변경

