### PR TITLE
[#123] JaCoCo 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,11 @@ plugins {
     id "org.asciidoctor.jvm.convert" version "3.3.2"
     id 'java'
     id 'checkstyle'
+    id 'jacoco'
+}
+
+jacoco {
+    toolVersion = '0.8.7'
 }
 
 checkstyle {
@@ -78,12 +83,13 @@ bootJar {
 test {
     useJUnitPlatform()
     outputs.dir snippetsDir
+    finalizedBy 'jacocoTestReport'
 }
 
 asciidoctor {
     configurations 'asciidoctorExtensions'
-    sources{
-        include("**/index.adoc","**/common/*.adoc")
+    sources {
+        include("**/index.adoc", "**/common/*.adoc")
     }
     inputs.dir snippetsDir
     dependsOn test
@@ -94,11 +100,20 @@ asciidoctor.doFirst {
     delete file('src/main/resources/static/docs')
 }
 
+jacocoTestReport {
+    reports {
+        html.enabled(true)
+        xml.enabled(false)
+        csv.enabled(false)
+    }
+}
+
 task copyDocument(type: Copy) {
     dependsOn asciidoctor
     from file("build/docs/asciidoc")
     into file("src/main/resources/static/docs")
 }
+
 
 build {
     dependsOn copyDocument


### PR DESCRIPTION
## 개요
- JaCoCo 적용

## 추가기능
- build/reports/jacoco/test/html 에서 테스트 커버리지 확인 가능


## 기타
- 테스트 커버리지 확인만 가능한 수준으로 적용했습니다. 일정 테스트 커버리지를 만족하지 못하면 빌드 실패가 되지는 않습니다!


