### PR TITLE
[#148] 메뉴 생성 API 유저 식별 방법으로 토큰을 사용하도록 변경

### DIFF
--- a/src/main/java/com/tasty/masiottae/franchise/domain/Franchise.java
+++ b/src/main/java/com/tasty/masiottae/franchise/domain/Franchise.java
@@ -39,6 +39,7 @@ public class Franchise extends BaseTimeEntity {
 
     @Builder
     private Franchise(Long id, String name, String logoUrl) {
+        this.id = id;
         this.name = name;
         this.logoUrl = logoUrl;
     }

--- a/src/main/java/com/tasty/masiottae/menu/controller/MenuController.java
+++ b/src/main/java/com/tasty/masiottae/menu/controller/MenuController.java
@@ -27,8 +27,9 @@ public class MenuController {
 
     @PostMapping(value = "/menu", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<MenuSaveResponse> saveMenu(@RequestPart MenuSaveRequest data,
-                                                     @RequestPart(required = false) MultipartFile image) {
-        return new ResponseEntity<>(menuService.createMenu(data, image), HttpStatus.CREATED);
+            @RequestPart(required = false) MultipartFile image, @LoginAccount Account account) {
+        return new ResponseEntity<>(menuService.createMenu(account, data, image),
+                HttpStatus.CREATED);
     }
 
     @GetMapping(value = "/menu/{menuId}")
@@ -39,14 +40,15 @@ public class MenuController {
 
     @PostMapping(value = "/menu/{menuId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> updateMenu(@RequestPart MenuUpdateRequest data,
-                                           @RequestPart(required = false) MultipartFile image,
-                                           @PathVariable Long menuId, @LoginAccount Account account) {
+            @RequestPart(required = false) MultipartFile image,
+            @PathVariable Long menuId, @LoginAccount Account account) {
         menuService.updateMenu(menuId, data, image, account);
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/menu/{menuId}")
-    public ResponseEntity<Void> deleteMenu(@PathVariable Long menuId, @LoginAccount Account account) {
+    public ResponseEntity<Void> deleteMenu(@PathVariable Long menuId,
+            @LoginAccount Account account) {
         menuService.delete(account, menuId);
         return ResponseEntity.ok().build();
     }
@@ -58,7 +60,8 @@ public class MenuController {
     }
 
     @GetMapping(value = "/menu", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<SearchMenuResponse> searchMenu(@ModelAttribute @Validated SearchMenuRequest request) {
+    public ResponseEntity<SearchMenuResponse> searchMenu(
+            @ModelAttribute @Validated SearchMenuRequest request) {
         return ResponseEntity.ok(menuService.searchAllMenu(request));
     }
 }

--- a/src/main/java/com/tasty/masiottae/menu/dto/MenuSaveRequest.java
+++ b/src/main/java/com/tasty/masiottae/menu/dto/MenuSaveRequest.java
@@ -7,7 +7,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.PositiveOrZero;
 import javax.validation.constraints.Size;
 
-public record MenuSaveRequest(@NotNull Long userId, @NotNull Long franchiseId,
+public record MenuSaveRequest(@NotNull Long franchiseId,
                               @NotBlank String title, @NotNull String content,
                               @NotBlank String originalTitle, @PositiveOrZero Integer expectedPrice,
                               @NotNull @Size(min = 1, max = 20) List<OptionSaveRequest> optionList,

--- a/src/main/java/com/tasty/masiottae/menu/service/MenuService.java
+++ b/src/main/java/com/tasty/masiottae/menu/service/MenuService.java
@@ -45,12 +45,10 @@ public class MenuService {
     private final FranchiseService franchiseService;
 
     @Transactional
-    public MenuSaveResponse createMenu(MenuSaveRequest request, MultipartFile image) {
+    public MenuSaveResponse createMenu(Account account, MenuSaveRequest request,
+            MultipartFile image) {
         String menuImageUrl = getImageUrl(null, image, false);
-
-        Menu menu = menuConverter.toMenu(request, menuImageUrl);
-        menuRepository.save(menu);
-
+        Menu menu = menuConverter.toMenu(account, request, menuImageUrl);
         return menuConverter
                 .toMenuSaveResponse(menuRepository.save(menu));
     }
@@ -76,14 +74,16 @@ public class MenuService {
     }
 
     @Transactional
-    public void updateMenu(Long menuId, MenuUpdateRequest request, MultipartFile image, Account account) {
+    public void updateMenu(Long menuId, MenuUpdateRequest request, MultipartFile image,
+            Account account) {
         Menu originMenu = findEntity(menuId);
 
         if (!originMenu.getAccount().getId().equals(account.getId())) {
             throw new ForbiddenException(ErrorMessage.NOT_ACCESS_ANOTHER_ACCOUNT.getMessage());
         }
 
-        String menuImageUrl = getImageUrl(originMenu.getPictureUrl(), image, request.isRemoveImage());
+        String menuImageUrl = getImageUrl(originMenu.getPictureUrl(), image,
+                request.isRemoveImage());
         Menu menu = menuConverter.toMenu(menuId, request, account, menuImageUrl);
         menuTasteRepository.deleteAll(menu.getMenuTasteList());
 
@@ -120,7 +120,8 @@ public class MenuService {
                         request.franchiseId());
         List<Taste> findTasteByIds = tasteService.findTasteByIds(request.tasteIdList());
         MenuSortCond sortCond = MenuSortCond.find(request.sort());
-        SearchCond searchCond = new SearchCond(null, request.keyword(), sortCond, franchise, findTasteByIds);
+        SearchCond searchCond = new SearchCond(null, request.keyword(), sortCond, franchise,
+                findTasteByIds);
         return searchMenu(searchCond, new PageInfo(request.offset(), request.limit()));
     }
 
@@ -128,7 +129,8 @@ public class MenuService {
         Account account = accountEntityService.findById(accountId);
         List<Taste> findTasteByIds = tasteService.findTasteByIds(request.tasteIdList());
         MenuSortCond sortCond = MenuSortCond.find(request.sort());
-        SearchCond searchCond = new SearchCond(account, request.keyword(), sortCond, null, findTasteByIds);
+        SearchCond searchCond = new SearchCond(account, request.keyword(), sortCond, null,
+                findTasteByIds);
         return searchMenu(searchCond, new PageInfo(request.offset(), request.limit()));
     }
 

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -816,14 +816,15 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /menu HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Accept: application/json
-X-CSRF-TOKEN: 6255db0c-1cc3-4a3c-b51d-dbfceda129e4
+Authorization: com.tasty.masiottae.security.jwt.JwtAccessToken@7fe0096
+X-CSRF-TOKEN: a15f41a4-c0b9-4044-a3f4-04be1a7e381f
 Host: localhost:8080
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Content-Disposition: form-data; name=data
 Content-Type: application/json
 
-{"userId":1,"franchiseId":1,"title":"슈렉 프라푸치노","content":"맛있습니다.","originalTitle":"그린티 프라푸치노","expectedPrice":10000,"optionList":[{"name":"에스프레소 샷","description":"1샷"},{"name":"간 자바칩","description":"1개"},{"name":"통 자바칩","description":"1개"},{"name":"카라멜드리즐","description":"1개"}],"tasteIdList":[1,2,3]}
+{"franchiseId":1,"title":"슈렉 프라푸치노","content":"맛있습니다.","originalTitle":"그린티 프라푸치노","expectedPrice":10000,"optionList":[{"name":"에스프레소 샷","description":"1샷"},{"name":"간 자바칩","description":"1개"},{"name":"통 자바칩","description":"1개"},{"name":"카라멜드리즐","description":"1개"}],"tasteIdList":[1,2,3]}
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Content-Disposition: form-data; name=image; filename=image.png
 Content-Type: image/png
@@ -900,11 +901,6 @@ sample image
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>userId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">회원 ID</p></td>
-</tr>
-<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>franchiseId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">프렌차이즈 ID</p></td>
@@ -967,7 +963,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 20
+Content-Length: 18
 
 {
   "menuId" : 1
@@ -1070,7 +1066,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 948
+Content-Length: 906
 
 {
   "id" : 1,
@@ -1088,7 +1084,7 @@ Content-Length: 948
     "nickName" : "닉네임",
     "email" : "유저이름",
     "snsAccount" : "이메일",
-    "createdAt" : "2022-08-11T17:31:32.066166",
+    "createdAt" : "2022-08-12T00:22:04.07662",
     "menuCount" : 10
   },
   "content" : "내용",
@@ -1111,8 +1107,8 @@ Content-Length: 948
     "name" : "파란맛",
     "color" : "파란색"
   } ],
-  "createdAt" : "2022-08-11T17:31:32.066166",
-  "updatedAt" : "2022-08-11T17:31:32.066166"
+  "createdAt" : "2022-08-12T00:22:04.076645",
+  "updatedAt" : "2022-08-12T00:22:04.076646"
 }</code></pre>
 </div>
 </div>
@@ -1271,8 +1267,8 @@ Content-Length: 948
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /menu/1 HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Accept: application/json
-Authorization: com.tasty.masiottae.security.jwt.JwtAccessToken@7fd7c0d4
-X-CSRF-TOKEN: 8c59e2ba-e624-4506-836b-2cfa08267164
+Authorization: com.tasty.masiottae.security.jwt.JwtAccessToken@22305fe3
+X-CSRF-TOKEN: 69e8d275-65d6-466e-8918-364de3e889c6
 Host: localhost:8080
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1437,9 +1433,9 @@ X-Frame-Options: DENY</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /menu/1 HTTP/1.1
-Authorization: com.tasty.masiottae.security.jwt.JwtAccessToken@18c14edd
+Authorization: com.tasty.masiottae.security.jwt.JwtAccessToken@782c5437
 Accept: application/json
-X-CSRF-TOKEN: 0dc759ec-6091-4fc3-8f69-01d757fe1705
+X-CSRF-TOKEN: 7b25aa62-f0bb-485f-b29e-b661ad71c780
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1570,7 +1566,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 2478
+Content-Length: 2374
 
 {
   "menu" : [ {
@@ -1589,7 +1585,7 @@ Content-Length: 2478
       "nickName" : "programmers",
       "email" : "prgrms@gmail.com",
       "snsAccount" : "prgrms123",
-      "createdAt" : "2022-08-11T17:31:32.3961937",
+      "createdAt" : "2022-08-12T00:22:04.222775",
       "menuCount" : 1
     },
     "content" : "맛있습니다.",
@@ -1619,8 +1615,8 @@ Content-Length: 2478
       "name" : "쓴맛",
       "color" : "#000000"
     } ],
-    "createdAt" : "2022-08-11T17:31:32.3961937",
-    "updatedAt" : "2022-08-11T17:31:32.3961937"
+    "createdAt" : "2022-08-12T00:22:04.222782",
+    "updatedAt" : "2022-08-12T00:22:04.222783"
   }, {
     "id" : 2,
     "franchise" : {
@@ -1637,7 +1633,7 @@ Content-Length: 2478
       "nickName" : "programmers",
       "email" : "prgrms@gmail.com",
       "snsAccount" : "prgrms123",
-      "createdAt" : "2022-08-11T17:31:32.3961937",
+      "createdAt" : "2022-08-12T00:22:04.222775",
       "menuCount" : 1
     },
     "content" : "맛있습니다.",
@@ -1667,8 +1663,8 @@ Content-Length: 2478
       "name" : "쓴맛",
       "color" : "#000000"
     } ],
-    "createdAt" : "2022-08-11T17:31:32.3961937",
-    "updatedAt" : "2022-08-11T17:31:32.3961937"
+    "createdAt" : "2022-08-12T00:22:04.222784",
+    "updatedAt" : "2022-08-12T00:22:04.222784"
   } ]
 }</code></pre>
 </div>
@@ -1933,7 +1929,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 2478
+Content-Length: 2374
 
 {
   "menu" : [ {
@@ -1952,7 +1948,7 @@ Content-Length: 2478
       "nickName" : "programmers",
       "email" : "prgrms@gmail.com",
       "snsAccount" : "prgrms123",
-      "createdAt" : "2022-08-11T17:31:32.2531902",
+      "createdAt" : "2022-08-12T00:22:04.158544",
       "menuCount" : 1
     },
     "content" : "맛있습니다.",
@@ -1982,8 +1978,8 @@ Content-Length: 2478
       "name" : "쓴맛",
       "color" : "#000000"
     } ],
-    "createdAt" : "2022-08-11T17:31:32.2531902",
-    "updatedAt" : "2022-08-11T17:31:32.2531902"
+    "createdAt" : "2022-08-12T00:22:04.158559",
+    "updatedAt" : "2022-08-12T00:22:04.158559"
   }, {
     "id" : 2,
     "franchise" : {
@@ -2000,7 +1996,7 @@ Content-Length: 2478
       "nickName" : "programmers",
       "email" : "prgrms@gmail.com",
       "snsAccount" : "prgrms123",
-      "createdAt" : "2022-08-11T17:31:32.2531902",
+      "createdAt" : "2022-08-12T00:22:04.158544",
       "menuCount" : 1
     },
     "content" : "맛있습니다.",
@@ -2030,8 +2026,8 @@ Content-Length: 2478
       "name" : "쓴맛",
       "color" : "#000000"
     } ],
-    "createdAt" : "2022-08-11T17:31:32.2531902",
-    "updatedAt" : "2022-08-11T17:31:32.2531902"
+    "createdAt" : "2022-08-12T00:22:04.158563",
+    "updatedAt" : "2022-08-12T00:22:04.158563"
   } ]
 }</code></pre>
 </div>
@@ -2281,7 +2277,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 196
+Content-Length: 184
 
 [ {
   "id" : 1,
@@ -2364,8 +2360,8 @@ Content-Length: 196
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /tastes HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
-Content-Length: 52
-X-CSRF-TOKEN: 36ec130e-3348-45cc-b5bf-80da3232dcb5
+Content-Length: 49
+X-CSRF-TOKEN: 12a992a2-73dc-45d0-9186-6b1d3a05d456
 Host: localhost:8080
 
 {
@@ -2444,7 +2440,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 21
+Content-Length: 19
 
 {
   "tasteId" : 1
@@ -2515,7 +2511,7 @@ Content-Length: 21
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /signup HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Accept: application/json
-X-CSRF-TOKEN: 19a884a1-d3e7-461f-8fdd-f9eb06ea7f54
+X-CSRF-TOKEN: 231f7419-b743-4d98-8f72-f1e55b8d348d
 Host: localhost:8080
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -2636,16 +2632,16 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 546
+Content-Length: 537
 
 {
   "accessToken" : {
     "token" : "bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0MjBAbmF2ZXIuY29tIiwicm9sZXMiOlsiUk9MRV9BQ0NPVU5UIl0sImV4cCI6MTY1OTQzMTI5Nn0.-cEvT2fbrz5mMpa_3Z0x4TASOEQFgk1-sT0lWU3IPR4",
-    "expirationDate" : "2022-08-11 17:31:19"
+    "expirationDate" : "2022-08-12 00:22:00"
   },
   "refreshToken" : {
     "token" : "bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0MjBAbmF2ZXIuY29tIiwicm9sZXMiOlsiUk9MRV9BQ0NPVU5UIl0sImV4cCI6MTY1OTQzMTI5Nn0.-cEvT2fbrz5mMpa_3Z0x4TASOEQFgk1-sT0lWU3IPR4",
-    "expirationDate" : "2022-08-11 17:31:19"
+    "expirationDate" : "2022-08-12 00:22:00"
   }
 }</code></pre>
 </div>
@@ -2915,7 +2911,7 @@ Content-Length: 260
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /accounts/1 HTTP/1.1
-X-CSRF-TOKEN: 56142750-feaa-41ff-8a32-ca18e1092a17
+X-CSRF-TOKEN: 96487908-e119-4cb5-95fb-451a89c6f1ff
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -3019,7 +3015,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 715
+Content-Length: 679
 
 {
   "content" : [ {
@@ -3028,7 +3024,7 @@ Content-Length: 715
     "nickName" : "nickname",
     "email" : "example@naver.com",
     "snsAccount" : "snsTest",
-    "createdAt" : "2022-08-11T17:31:20.0234854",
+    "createdAt" : "2022-08-12T00:22:01.008996",
     "menuCount" : 0
   } ],
   "pageable" : {
@@ -3038,14 +3034,14 @@ Content-Length: 715
       "unsorted" : true
     },
     "offset" : 0,
-    "pageNumber" : 0,
     "pageSize" : 10,
+    "pageNumber" : 0,
     "paged" : true,
     "unpaged" : false
   },
   "totalPages" : 1,
-  "last" : true,
   "totalElements" : 1,
+  "last" : true,
   "size" : 10,
   "number" : 0,
   "sort" : {
@@ -3053,8 +3049,8 @@ Content-Length: 715
     "sorted" : false,
     "unsorted" : true
   },
-  "first" : true,
   "numberOfElements" : 1,
+  "first" : true,
   "empty" : false
 }</code></pre>
 </div>
@@ -3309,7 +3305,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 197
+Content-Length: 188
 
 {
   "id" : 1,
@@ -3317,7 +3313,7 @@ Content-Length: 197
   "nickName" : "nickname",
   "email" : "example@naver.com",
   "snsAccount" : "snsTest",
-  "createdAt" : "2022-08-11T17:31:20.4584951",
+  "createdAt" : "2022-08-12T00:22:01.109875",
   "menuCount" : 0
 }</code></pre>
 </div>
@@ -3410,8 +3406,8 @@ Content-Length: 197
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /accounts/1/password HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Content-Length: 35
-X-CSRF-TOKEN: b5a4016e-17e2-45a1-9eae-86f5b51a7813
+Content-Length: 33
+X-CSRF-TOKEN: 46d5b668-74b5-443f-bca2-754634997c37
 Host: localhost:8080
 
 {
@@ -3475,8 +3471,8 @@ Host: localhost:8080
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /accounts/1/nick-name HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
-Content-Length: 42
-X-CSRF-TOKEN: 59b1ee54-d899-4450-967e-e303ba35d65d
+Content-Length: 40
+X-CSRF-TOKEN: cc8fa146-034a-4d37-9be2-0b1a755275a5
 Host: localhost:8080
 
 {
@@ -3545,7 +3541,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 49
+Content-Length: 47
 
 {
   "updatedNickName" : "변경된 닉네임"
@@ -3611,8 +3607,8 @@ Content-Length: 49
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /accounts/1/sns HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
-Content-Length: 45
-X-CSRF-TOKEN: 5dd8dc48-9fb1-44e3-a39d-fe757686f7a8
+Content-Length: 43
+X-CSRF-TOKEN: e902a03e-e385-44e0-98f4-f8b4780fd958
 Host: localhost:8080
 
 {
@@ -3681,7 +3677,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 55
+Content-Length: 53
 
 {
   "updatedSnsAccount" : "변경된 SNS 닉네임"
@@ -3747,7 +3743,7 @@ Content-Length: 55
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /accounts/1/image HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Accept: application/json
-X-CSRF-TOKEN: 030c06fd-ad24-4cf4-9de5-d53c07ce5ac3
+X-CSRF-TOKEN: f3760847-16ed-451a-ad32-e4d8e0a1b9e7
 Host: localhost:8080
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -3820,7 +3816,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 50
+Content-Length: 48
 
 {
   "image" : "https://localhost/abcdefg.jpeg"
@@ -3950,7 +3946,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 56
+Content-Length: 53
 
 {
   "isDuplicated" : false,
@@ -4022,8 +4018,8 @@ Content-Length: 56
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /re-issue HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
-Content-Length: 439
-X-CSRF-TOKEN: c01b7557-55e6-42b4-bda0-e9778c921a62
+Content-Length: 435
+X-CSRF-TOKEN: dfae0e92-61e0-4242-8f0d-af56d7a0f6c0
 Host: localhost:8080
 
 {
@@ -4108,11 +4104,11 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 245
+Content-Length: 242
 
 {
   "token" : "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0MTExQG5hdmVyLmNvbSIsInJvbGVzIjpbIlJPTEVfQUNDT1VOVCJdLCJleHAiOjE2NjAwMzg0NzN9.DZDkCcMNAtfxmv-GWL9mxE0dncwxbHBQQ9kXmvG2AMA",
-  "expirationDate" : "2022-08-11 17:31:20"
+  "expirationDate" : "2022-08-12 00:22:01"
 }</code></pre>
 </div>
 </div>
@@ -4179,8 +4175,8 @@ Content-Length: 245
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /logout HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Content-Length: 439
-X-CSRF-TOKEN: 23c25ab7-ca11-4f31-9237-ba9e592f404b
+Content-Length: 435
+X-CSRF-TOKEN: 82a18ea7-718c-4613-b862-1ca9b19dd7f8
 Host: localhost:8080
 
 {
@@ -4279,9 +4275,9 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 407
+Content-Length: 408
 
-[{"id":6,"image":"logo1","name":"franchise1"},{"id":3,"image":"logo2","name":"franchise2"},{"id":10,"image":"logo3","name":"franchise3"},{"id":5,"image":"logo4","name":"franchise4"},{"id":7,"image":"logo5","name":"franchise5"},{"id":6,"image":"logo6","name":"franchise6"},{"id":2,"image":"logo7","name":"franchise7"},{"id":5,"image":"logo8","name":"franchise8"},{"id":8,"image":"logo9","name":"franchise9"}]</code></pre>
+[{"id":4,"image":"logo1","name":"franchise1"},{"id":5,"image":"logo2","name":"franchise2"},{"id":6,"image":"logo3","name":"franchise3"},{"id":10,"image":"logo4","name":"franchise4"},{"id":1,"image":"logo5","name":"franchise5"},{"id":6,"image":"logo6","name":"franchise6"},{"id":5,"image":"logo7","name":"franchise7"},{"id":5,"image":"logo8","name":"franchise8"},{"id":10,"image":"logo9","name":"franchise9"}]</code></pre>
 </div>
 </div>
 </div>
@@ -4289,7 +4285,7 @@ Content-Length: 407
 <h4 id="_프랜차이즈_전체_조회_response_body"><a class="link" href="#_프랜차이즈_전체_조회_response_body">Response body</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-none hljs">[{"id":6,"image":"logo1","name":"franchise1"},{"id":3,"image":"logo2","name":"franchise2"},{"id":10,"image":"logo3","name":"franchise3"},{"id":5,"image":"logo4","name":"franchise4"},{"id":7,"image":"logo5","name":"franchise5"},{"id":6,"image":"logo6","name":"franchise6"},{"id":2,"image":"logo7","name":"franchise7"},{"id":5,"image":"logo8","name":"franchise8"},{"id":8,"image":"logo9","name":"franchise9"}]</code></pre>
+<pre class="highlightjs highlight nowrap"><code class="language-none hljs">[{"id":4,"image":"logo1","name":"franchise1"},{"id":5,"image":"logo2","name":"franchise2"},{"id":6,"image":"logo3","name":"franchise3"},{"id":10,"image":"logo4","name":"franchise4"},{"id":1,"image":"logo5","name":"franchise5"},{"id":6,"image":"logo6","name":"franchise6"},{"id":5,"image":"logo7","name":"franchise7"},{"id":5,"image":"logo8","name":"franchise8"},{"id":10,"image":"logo9","name":"franchise9"}]</code></pre>
 </div>
 </div>
 </div>
@@ -4340,9 +4336,9 @@ Content-Length: 407
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /menu/1/like HTTP/1.1
-Authorization: com.tasty.masiottae.security.jwt.JwtAccessToken@5df93620
+Authorization: com.tasty.masiottae.security.jwt.JwtAccessToken@3fcae35c
 Accept: application/json
-X-CSRF-TOKEN: 0473f98a-21ff-4ae3-8741-7e94175c3f7d
+X-CSRF-TOKEN: 0f047128-b78d-489c-aacb-2f642bc3b177
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -4419,7 +4415,7 @@ X-Frame-Options: DENY</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /accounts/like?page=0&amp;size=10 HTTP/1.1
-Authorization: com.tasty.masiottae.security.jwt.JwtAccessToken@59be0306
+Authorization: com.tasty.masiottae.security.jwt.JwtAccessToken@546aa43c
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -4440,7 +4436,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 1535
+Content-Length: 1463
 
 {
   "content" : [ {
@@ -4459,7 +4455,7 @@ Content-Length: 1535
       "nickName" : "닉네임",
       "email" : "유저이름",
       "snsAccount" : "이메일",
-      "createdAt" : "2022-08-11T17:31:30.1868253",
+      "createdAt" : "2022-08-12T00:22:03.655485",
       "menuCount" : 10
     },
     "content" : "내용",
@@ -4482,8 +4478,8 @@ Content-Length: 1535
       "name" : "파란맛",
       "color" : "파란색"
     } ],
-    "createdAt" : "2022-08-11T17:31:30.1868253",
-    "updatedAt" : "2022-08-11T17:31:30.1868253"
+    "createdAt" : "2022-08-12T00:22:03.655519",
+    "updatedAt" : "2022-08-12T00:22:03.65552"
   } ],
   "pageable" : {
     "sort" : {
@@ -4492,14 +4488,14 @@ Content-Length: 1535
       "unsorted" : true
     },
     "offset" : 0,
-    "pageNumber" : 0,
     "pageSize" : 10,
+    "pageNumber" : 0,
     "paged" : true,
     "unpaged" : false
   },
   "totalPages" : 1,
-  "last" : true,
   "totalElements" : 1,
+  "last" : true,
   "size" : 10,
   "number" : 0,
   "sort" : {
@@ -4507,8 +4503,8 @@ Content-Length: 1535
     "sorted" : false,
     "unsorted" : true
   },
-  "first" : true,
   "numberOfElements" : 1,
+  "first" : true,
   "empty" : false
 }</code></pre>
 </div>
@@ -4798,7 +4794,7 @@ Content-Length: 1535
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /comments HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Content-Length: 48
-X-CSRF-TOKEN: 498faca9-1c53-44ae-8a27-d4f7ff0ae554
+X-CSRF-TOKEN: 928b59c2-1ec1-4eef-96ee-52c5a0e7cd0b
 Host: localhost:8080
 
 {"userId":1,"menuId":1,"comment":"댓글내용"}</code></pre>
@@ -4872,7 +4868,7 @@ Content-Length: 51
 <h4 id="_댓글_작성_response_body"><a class="link" href="#_댓글_작성_response_body">Response body</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{"menuId":1,"commentId":1,"comment":"�뙎湲��궡�슜"}</code></pre>
+<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{"menuId":1,"commentId":1,"comment":"댓글내용"}</code></pre>
 </div>
 </div>
 </div>
@@ -4960,9 +4956,9 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 2927
+Content-Length: 2894
 
-[{"id":1,"menuId":1,"author":{"id":1,"image":"profile1","nickName":"nickname1","email":"test1@gmail.com","snsAccount":"sns1","createdAt":"2022-08-11T17:31:22.5707748","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-11T17:31:22.5717763","updatedAt":"2022-08-11T17:31:22.5717763"},{"id":2,"menuId":1,"author":{"id":2,"image":"profile2","nickName":"nickname2","email":"test2@gmail.com","snsAccount":"sns2","createdAt":"2022-08-11T17:31:22.5707748","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-11T17:31:22.5717763","updatedAt":"2022-08-11T17:31:22.5717763"},{"id":3,"menuId":1,"author":{"id":3,"image":"profile3","nickName":"nickname3","email":"test3@gmail.com","snsAccount":"sns3","createdAt":"2022-08-11T17:31:22.5707748","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-11T17:31:22.5717763","updatedAt":"2022-08-11T17:31:22.5717763"},{"id":4,"menuId":1,"author":{"id":4,"image":"profile4","nickName":"nickname4","email":"test4@gmail.com","snsAccount":"sns4","createdAt":"2022-08-11T17:31:22.5707748","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-11T17:31:22.5717763","updatedAt":"2022-08-11T17:31:22.5717763"},{"id":5,"menuId":1,"author":{"id":5,"image":"profile5","nickName":"nickname5","email":"test5@gmail.com","snsAccount":"sns5","createdAt":"2022-08-11T17:31:22.5707748","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-11T17:31:22.5717763","updatedAt":"2022-08-11T17:31:22.5717763"},{"id":6,"menuId":1,"author":{"id":6,"image":"profile6","nickName":"nickname6","email":"test6@gmail.com","snsAccount":"sns6","createdAt":"2022-08-11T17:31:22.5707748","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-11T17:31:22.5717763","updatedAt":"2022-08-11T17:31:22.5717763"},{"id":7,"menuId":1,"author":{"id":7,"image":"profile7","nickName":"nickname7","email":"test7@gmail.com","snsAccount":"sns7","createdAt":"2022-08-11T17:31:22.5707748","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-11T17:31:22.5717763","updatedAt":"2022-08-11T17:31:22.5717763"},{"id":8,"menuId":1,"author":{"id":8,"image":"profile8","nickName":"nickname8","email":"test8@gmail.com","snsAccount":"sns8","createdAt":"2022-08-11T17:31:22.5707748","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-11T17:31:22.5717763","updatedAt":"2022-08-11T17:31:22.5717763"},{"id":9,"menuId":1,"author":{"id":9,"image":"profile9","nickName":"nickname9","email":"test9@gmail.com","snsAccount":"sns9","createdAt":"2022-08-11T17:31:22.5707748","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-11T17:31:22.5717763","updatedAt":"2022-08-11T17:31:22.5717763"},{"id":10,"menuId":1,"author":{"id":10,"image":"profile10","nickName":"nickname10","email":"test10@gmail.com","snsAccount":"sns10","createdAt":"2022-08-11T17:31:22.5707748","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-11T17:31:22.5717763","updatedAt":"2022-08-11T17:31:22.5717763"}]</code></pre>
+[{"id":1,"menuId":1,"author":{"id":1,"image":"profile1","nickName":"nickname1","email":"test1@gmail.com","snsAccount":"sns1","createdAt":"2022-08-12T00:22:01.667896","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-12T00:22:01.6682","updatedAt":"2022-08-12T00:22:01.668202"},{"id":2,"menuId":1,"author":{"id":2,"image":"profile2","nickName":"nickname2","email":"test2@gmail.com","snsAccount":"sns2","createdAt":"2022-08-12T00:22:01.667907","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-12T00:22:01.668258","updatedAt":"2022-08-12T00:22:01.668259"},{"id":3,"menuId":1,"author":{"id":3,"image":"profile3","nickName":"nickname3","email":"test3@gmail.com","snsAccount":"sns3","createdAt":"2022-08-12T00:22:01.667911","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-12T00:22:01.668261","updatedAt":"2022-08-12T00:22:01.668261"},{"id":4,"menuId":1,"author":{"id":4,"image":"profile4","nickName":"nickname4","email":"test4@gmail.com","snsAccount":"sns4","createdAt":"2022-08-12T00:22:01.667913","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-12T00:22:01.668262","updatedAt":"2022-08-12T00:22:01.668263"},{"id":5,"menuId":1,"author":{"id":5,"image":"profile5","nickName":"nickname5","email":"test5@gmail.com","snsAccount":"sns5","createdAt":"2022-08-12T00:22:01.667915","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-12T00:22:01.668263","updatedAt":"2022-08-12T00:22:01.668264"},{"id":6,"menuId":1,"author":{"id":6,"image":"profile6","nickName":"nickname6","email":"test6@gmail.com","snsAccount":"sns6","createdAt":"2022-08-12T00:22:01.667917","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-12T00:22:01.668265","updatedAt":"2022-08-12T00:22:01.668265"},{"id":7,"menuId":1,"author":{"id":7,"image":"profile7","nickName":"nickname7","email":"test7@gmail.com","snsAccount":"sns7","createdAt":"2022-08-12T00:22:01.667927","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-12T00:22:01.668266","updatedAt":"2022-08-12T00:22:01.668268"},{"id":8,"menuId":1,"author":{"id":8,"image":"profile8","nickName":"nickname8","email":"test8@gmail.com","snsAccount":"sns8","createdAt":"2022-08-12T00:22:01.667929","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-12T00:22:01.66827","updatedAt":"2022-08-12T00:22:01.668271"},{"id":9,"menuId":1,"author":{"id":9,"image":"profile9","nickName":"nickname9","email":"test9@gmail.com","snsAccount":"sns9","createdAt":"2022-08-12T00:22:01.667931","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-12T00:22:01.668271","updatedAt":"2022-08-12T00:22:01.668272"},{"id":10,"menuId":1,"author":{"id":10,"image":"profile10","nickName":"nickname10","email":"test10@gmail.com","snsAccount":"sns10","createdAt":"2022-08-12T00:22:01.667935","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-12T00:22:01.668273","updatedAt":"2022-08-12T00:22:01.668273"}]</code></pre>
 </div>
 </div>
 </div>
@@ -4970,7 +4966,7 @@ Content-Length: 2927
 <h4 id="_특정_메뉴에_달려있는_댓글_조회_response_body"><a class="link" href="#_특정_메뉴에_달려있는_댓글_조회_response_body">Response body</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-none hljs">[{"id":1,"menuId":1,"author":{"id":1,"image":"profile1","nickName":"nickname1","email":"test1@gmail.com","snsAccount":"sns1","createdAt":"2022-08-11T17:31:22.5707748","menuCount":10},"comment":"�뙎湲��궡�슜","createdAt":"2022-08-11T17:31:22.5717763","updatedAt":"2022-08-11T17:31:22.5717763"},{"id":2,"menuId":1,"author":{"id":2,"image":"profile2","nickName":"nickname2","email":"test2@gmail.com","snsAccount":"sns2","createdAt":"2022-08-11T17:31:22.5707748","menuCount":10},"comment":"�뙎湲��궡�슜","createdAt":"2022-08-11T17:31:22.5717763","updatedAt":"2022-08-11T17:31:22.5717763"},{"id":3,"menuId":1,"author":{"id":3,"image":"profile3","nickName":"nickname3","email":"test3@gmail.com","snsAccount":"sns3","createdAt":"2022-08-11T17:31:22.5707748","menuCount":10},"comment":"�뙎湲��궡�슜","createdAt":"2022-08-11T17:31:22.5717763","updatedAt":"2022-08-11T17:31:22.5717763"},{"id":4,"menuId":1,"author":{"id":4,"image":"profile4","nickName":"nickname4","email":"test4@gmail.com","snsAccount":"sns4","createdAt":"2022-08-11T17:31:22.5707748","menuCount":10},"comment":"�뙎湲��궡�슜","createdAt":"2022-08-11T17:31:22.5717763","updatedAt":"2022-08-11T17:31:22.5717763"},{"id":5,"menuId":1,"author":{"id":5,"image":"profile5","nickName":"nickname5","email":"test5@gmail.com","snsAccount":"sns5","createdAt":"2022-08-11T17:31:22.5707748","menuCount":10},"comment":"�뙎湲��궡�슜","createdAt":"2022-08-11T17:31:22.5717763","updatedAt":"2022-08-11T17:31:22.5717763"},{"id":6,"menuId":1,"author":{"id":6,"image":"profile6","nickName":"nickname6","email":"test6@gmail.com","snsAccount":"sns6","createdAt":"2022-08-11T17:31:22.5707748","menuCount":10},"comment":"�뙎湲��궡�슜","createdAt":"2022-08-11T17:31:22.5717763","updatedAt":"2022-08-11T17:31:22.5717763"},{"id":7,"menuId":1,"author":{"id":7,"image":"profile7","nickName":"nickname7","email":"test7@gmail.com","snsAccount":"sns7","createdAt":"2022-08-11T17:31:22.5707748","menuCount":10},"comment":"�뙎湲��궡�슜","createdAt":"2022-08-11T17:31:22.5717763","updatedAt":"2022-08-11T17:31:22.5717763"},{"id":8,"menuId":1,"author":{"id":8,"image":"profile8","nickName":"nickname8","email":"test8@gmail.com","snsAccount":"sns8","createdAt":"2022-08-11T17:31:22.5707748","menuCount":10},"comment":"�뙎湲��궡�슜","createdAt":"2022-08-11T17:31:22.5717763","updatedAt":"2022-08-11T17:31:22.5717763"},{"id":9,"menuId":1,"author":{"id":9,"image":"profile9","nickName":"nickname9","email":"test9@gmail.com","snsAccount":"sns9","createdAt":"2022-08-11T17:31:22.5707748","menuCount":10},"comment":"�뙎湲��궡�슜","createdAt":"2022-08-11T17:31:22.5717763","updatedAt":"2022-08-11T17:31:22.5717763"},{"id":10,"menuId":1,"author":{"id":10,"image":"profile10","nickName":"nickname10","email":"test10@gmail.com","snsAccount":"sns10","createdAt":"2022-08-11T17:31:22.5707748","menuCount":10},"comment":"�뙎湲��궡�슜","createdAt":"2022-08-11T17:31:22.5717763","updatedAt":"2022-08-11T17:31:22.5717763"}]</code></pre>
+<pre class="highlightjs highlight nowrap"><code class="language-none hljs">[{"id":1,"menuId":1,"author":{"id":1,"image":"profile1","nickName":"nickname1","email":"test1@gmail.com","snsAccount":"sns1","createdAt":"2022-08-12T00:22:01.667896","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-12T00:22:01.6682","updatedAt":"2022-08-12T00:22:01.668202"},{"id":2,"menuId":1,"author":{"id":2,"image":"profile2","nickName":"nickname2","email":"test2@gmail.com","snsAccount":"sns2","createdAt":"2022-08-12T00:22:01.667907","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-12T00:22:01.668258","updatedAt":"2022-08-12T00:22:01.668259"},{"id":3,"menuId":1,"author":{"id":3,"image":"profile3","nickName":"nickname3","email":"test3@gmail.com","snsAccount":"sns3","createdAt":"2022-08-12T00:22:01.667911","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-12T00:22:01.668261","updatedAt":"2022-08-12T00:22:01.668261"},{"id":4,"menuId":1,"author":{"id":4,"image":"profile4","nickName":"nickname4","email":"test4@gmail.com","snsAccount":"sns4","createdAt":"2022-08-12T00:22:01.667913","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-12T00:22:01.668262","updatedAt":"2022-08-12T00:22:01.668263"},{"id":5,"menuId":1,"author":{"id":5,"image":"profile5","nickName":"nickname5","email":"test5@gmail.com","snsAccount":"sns5","createdAt":"2022-08-12T00:22:01.667915","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-12T00:22:01.668263","updatedAt":"2022-08-12T00:22:01.668264"},{"id":6,"menuId":1,"author":{"id":6,"image":"profile6","nickName":"nickname6","email":"test6@gmail.com","snsAccount":"sns6","createdAt":"2022-08-12T00:22:01.667917","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-12T00:22:01.668265","updatedAt":"2022-08-12T00:22:01.668265"},{"id":7,"menuId":1,"author":{"id":7,"image":"profile7","nickName":"nickname7","email":"test7@gmail.com","snsAccount":"sns7","createdAt":"2022-08-12T00:22:01.667927","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-12T00:22:01.668266","updatedAt":"2022-08-12T00:22:01.668268"},{"id":8,"menuId":1,"author":{"id":8,"image":"profile8","nickName":"nickname8","email":"test8@gmail.com","snsAccount":"sns8","createdAt":"2022-08-12T00:22:01.667929","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-12T00:22:01.66827","updatedAt":"2022-08-12T00:22:01.668271"},{"id":9,"menuId":1,"author":{"id":9,"image":"profile9","nickName":"nickname9","email":"test9@gmail.com","snsAccount":"sns9","createdAt":"2022-08-12T00:22:01.667931","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-12T00:22:01.668271","updatedAt":"2022-08-12T00:22:01.668272"},{"id":10,"menuId":1,"author":{"id":10,"image":"profile10","nickName":"nickname10","email":"test10@gmail.com","snsAccount":"sns10","createdAt":"2022-08-12T00:22:01.667935","menuCount":10},"comment":"댓글내용","createdAt":"2022-08-12T00:22:01.668273","updatedAt":"2022-08-12T00:22:01.668273"}]</code></pre>
 </div>
 </div>
 </div>
@@ -5062,10 +5058,10 @@ Content-Length: 2927
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /comments/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: com.tasty.masiottae.security.jwt.JwtAccessToken@2903c791
+Authorization: com.tasty.masiottae.security.jwt.JwtAccessToken@1e06afd3
 Accept: application/json
 Content-Length: 37
-X-CSRF-TOKEN: 2338644f-ffbc-477e-99d5-d89acb10cd8c
+X-CSRF-TOKEN: fb6153b4-9845-434c-86a7-548c41048cfb
 Host: localhost:8080
 
 {"comment":"새로운 댓글 내용"}</code></pre>
@@ -5168,9 +5164,9 @@ X-Frame-Options: DENY</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /comments/1 HTTP/1.1
-Authorization: com.tasty.masiottae.security.jwt.JwtAccessToken@19181a89
+Authorization: com.tasty.masiottae.security.jwt.JwtAccessToken@5224f786
 Accept: application/json
-X-CSRF-TOKEN: 7f644ad9-a649-48af-8350-4313cfad5e8f
+X-CSRF-TOKEN: 22aa7901-0d65-48c2-ac28-466a9c407456
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -5246,7 +5242,7 @@ X-Frame-Options: DENY</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2022-08-10 17:36:48 +0900
+Last updated 2022-08-09 14:42:08 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/test/java/com/tasty/masiottae/likemenu/service/LikeMenuServiceTest.java
+++ b/src/test/java/com/tasty/masiottae/likemenu/service/LikeMenuServiceTest.java
@@ -77,12 +77,8 @@ class LikeMenuServiceTest {
 
     @BeforeEach
     void init() {
-        account = Account.createAccount("test@gmail.com", "password", "nickname", "imageUrl");
-
-        franchise = Franchise.createFranchise("starbucks", "logo");
-
-        accountRepository.save(account);
-        franchiseRepository.save(franchise);
+        account = accountRepository.save(Account.createAccount("test@gmail.com", "password", "nickname", "imageUrl"));
+        franchise = franchiseRepository.save(Franchise.createFranchise("starbucks", "logo"));
 
         // Given
         List<OptionSaveRequest> optionSaveRequests = List.of(new OptionSaveRequest("옵션1", "설명1"),
@@ -95,12 +91,12 @@ class LikeMenuServiceTest {
         MockMultipartFile multipartFile = new MockMultipartFile("file", "image.png", "img/png",
                 "Hello".getBytes());
 
-        MenuSaveRequest request = new MenuSaveRequest(account.getId(),
-                franchise.getId(), "커스텀 이름", "맛있습니다", "원래 메뉴 이름", 15000, optionSaveRequests,
+        MenuSaveRequest request = new MenuSaveRequest(this.franchise.getId(), "커스텀 이름", "맛있습니다",
+                "원래 메뉴 이름", 15000, optionSaveRequests,
                 List.of(tastes.get(0).getId(), tastes.get(1).getId(), tastes.get(2).getId()));
 
         // When
-        MenuSaveResponse menuSaveResponse = menuService.createMenu(request, multipartFile);
+        MenuSaveResponse menuSaveResponse = menuService.createMenu(account, request, multipartFile);
 
         // Then
         Menu menu = menuRepository.findById(menuSaveResponse.menuId()).get();

--- a/src/test/java/com/tasty/masiottae/menu/controller/MenuControllerTest.java
+++ b/src/test/java/com/tasty/masiottae/menu/controller/MenuControllerTest.java
@@ -28,18 +28,24 @@ import com.tasty.masiottae.account.dto.AccountFindResponse;
 import com.tasty.masiottae.config.RestDocsConfiguration;
 import com.tasty.masiottae.config.WithMockAccount;
 import com.tasty.masiottae.franchise.dto.FranchiseFindResponse;
-import com.tasty.masiottae.menu.dto.*;
+import com.tasty.masiottae.menu.dto.MenuFindResponse;
+import com.tasty.masiottae.menu.dto.MenuSaveRequest;
+import com.tasty.masiottae.menu.dto.MenuSaveResponse;
+import com.tasty.masiottae.menu.dto.MenuUpdateRequest;
+import com.tasty.masiottae.menu.dto.SearchMenuRequest;
+import com.tasty.masiottae.menu.dto.SearchMenuResponse;
+import com.tasty.masiottae.menu.dto.SearchMyMenuRequest;
+import com.tasty.masiottae.menu.dto.TasteFindResponse;
 import com.tasty.masiottae.menu.service.MenuService;
 import com.tasty.masiottae.option.dto.OptionFindResponse;
 import com.tasty.masiottae.option.dto.OptionSaveRequest;
 import com.tasty.masiottae.security.config.SecurityConfig;
 import com.tasty.masiottae.security.filter.JwtAuthenticationFilter;
 import com.tasty.masiottae.security.filter.JwtAuthorizationFilter;
+import com.tasty.masiottae.security.jwt.JwtAccessToken;
 import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
-
-import com.tasty.masiottae.security.jwt.JwtAccessToken;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,7 +59,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = MenuController.class, excludeFilters = {
@@ -72,6 +77,13 @@ class MenuControllerTest {
     MenuService menuService;
     @Autowired
     private MockMvc mockMvc;
+
+    JwtAccessToken token = new JwtAccessToken(
+            "bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9"
+                    + ".eyJzdWIiOiJ0ZXN0MjBAbmF2ZXIuY29tIiwicm9sZXMiO"
+                    + "lsiUk9MRV9BQ0NPVU5UIl0sImV4cCI6MTY1OTQzMTI5Nn0."
+                    + "-cEvT2fbrz5mMpa_3Z0x4TASOEQFgk1-sT0lWU3IPR4",
+            new Date());
 
     @Test
     @DisplayName("메뉴 단건 조회")
@@ -148,7 +160,7 @@ class MenuControllerTest {
 
         List<Long> tasteIds = List.of(1L, 2L, 3L);
 
-        MenuSaveRequest menuSaveRequest = new MenuSaveRequest(1L, 1L, "슈렉 프라푸치노",
+        MenuSaveRequest menuSaveRequest = new MenuSaveRequest(1L, "슈렉 프라푸치노",
                 "맛있습니다.",
                 "그린티 프라푸치노", 10000, optionSaveRequests, tasteIds);
 
@@ -158,15 +170,15 @@ class MenuControllerTest {
         MockMultipartFile imageFile = new MockMultipartFile("image", "image.png", "image/png",
                 "sample image".getBytes());
 
-        given(menuService.createMenu(menuSaveRequest, imageFile)).willReturn(
+        given(menuService.createMenu(any(), any(), any())).willReturn(
                 new MenuSaveResponse(1L));
-
-
 
         // When // Then
         mockMvc.perform(multipart("/menu").file(data).file(imageFile)
                         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                        .accept(MediaType.APPLICATION_JSON_VALUE).with(csrf().asHeader())).andDo(print())
+                        .accept(MediaType.APPLICATION_JSON_VALUE)
+                        .with(csrf().asHeader())
+                        .header("Authorization", token))
                 .andExpect(status().isCreated()).andDo(document("create-menu", requestHeaders(
                                 headerWithName(HttpHeaders.CONTENT_TYPE).description(
                                         MediaType.MULTIPART_FORM_DATA_VALUE),
@@ -176,7 +188,6 @@ class MenuControllerTest {
                                 partWithName("data").description("메뉴 정보")
 
                         ), requestPartFields("data",
-                                fieldWithPath("userId").type(JsonFieldType.NUMBER).description("회원 ID"),
                                 fieldWithPath("franchiseId").type(JsonFieldType.NUMBER)
                                         .description("프렌차이즈 ID"),
                                 fieldWithPath("title").type(JsonFieldType.STRING).description("메뉴명"),
@@ -198,7 +209,7 @@ class MenuControllerTest {
                                 fieldWithPath("menuId").type(JsonFieldType.NUMBER)
                                         .description("생성된 메뉴 ID"))));
 
-        then(menuService).should().createMenu(menuSaveRequest, imageFile);
+        then(menuService).should().createMenu(any(), any(), any());
     }
 
     @Test
@@ -225,14 +236,7 @@ class MenuControllerTest {
         MockMultipartFile imageFile = new MockMultipartFile("image", "image.png",
                 "image/png", "sample image".getBytes());
 
-        JwtAccessToken token = new JwtAccessToken(
-                "bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9"
-                        + ".eyJzdWIiOiJ0ZXN0MjBAbmF2ZXIuY29tIiwicm9sZXMiO"
-                        + "lsiUk9MRV9BQ0NPVU5UIl0sImV4cCI6MTY1OTQzMTI5Nn0."
-                        + "-cEvT2fbrz5mMpa_3Z0x4TASOEQFgk1-sT0lWU3IPR4",
-                new Date());
-
-        given(menuService.createMenu(any(), any()))
+        given(menuService.createMenu(any(), any(), any()))
                 .willReturn(new MenuSaveResponse(1L));
 
         mockMvc.perform(multipart("/menu/{menuId}", 1)
@@ -279,7 +283,8 @@ class MenuControllerTest {
                                         .description("옵션 설명"),
                                 fieldWithPath("tasteIdList[]").type(JsonFieldType.ARRAY)
                                         .description("맛 ID 목록"),
-                                fieldWithPath("isRemoveImage").type(JsonFieldType.BOOLEAN).description("이미지가 제거 유무.")
+                                fieldWithPath("isRemoveImage").type(JsonFieldType.BOOLEAN)
+                                        .description("이미지가 제거 유무.")
                         )
                 ));
     }
@@ -287,12 +292,6 @@ class MenuControllerTest {
     @Test
     @DisplayName("메뉴를 삭제한다.")
     public void deleteMenuTest() throws Exception {
-        JwtAccessToken token = new JwtAccessToken(
-                "bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9"
-                        + ".eyJzdWIiOiJ0ZXN0MjBAbmF2ZXIuY29tIiwicm9sZXMiO"
-                        + "lsiUk9MRV9BQ0NPVU5UIl0sImV4cCI6MTY1OTQzMTI5Nn0."
-                        + "-cEvT2fbrz5mMpa_3Z0x4TASOEQFgk1-sT0lWU3IPR4",
-                new Date());
         Long menuId = 1L;
         mockMvc.perform(delete("/menu/{menuId}", menuId)
                         .with(csrf().asHeader())


### PR DESCRIPTION
## 개요
- 메뉴 생성 API 유저 식별 방법으로 토큰을 사용하도록 변경

## 변경사항(Optional)
- 메뉴 생성 API에서 기존 request body 를 통해 유저를 식별하던 방식에서 토큰을 통해 유저를 식별하는 방식으로 변경
- Franchise 생성자에서 id 설정이 누락되었던 문제 수정
## 기타
- Todo : MenuConverter에서 TasteService 의존성 제거