### PR TITLE
[#164] 메뉴 검색 API keyword 파라미터 null 전달시 500 응답이 발생하는 버그 수정

### DIFF
--- a/src/main/java/com/tasty/masiottae/menu/repository/MenuRepositoryImpl.java
+++ b/src/main/java/com/tasty/masiottae/menu/repository/MenuRepositoryImpl.java
@@ -36,8 +36,8 @@ public class MenuRepositoryImpl implements MenuRepositoryCustom {
     private BooleanExpression[] searchExpression(SearchCond searchCond) {
         return switch (searchCond.searchType()) {
             case ALL_MENU -> allSearchCond(searchCond);
-            case LIKE_MENU -> mySearchCond(searchCond);
-            case MY_MENU -> likeSearchCond(searchCond);
+            case LIKE_MENU -> likeSearchCond(searchCond);
+            case MY_MENU -> mySearchCond(searchCond);
         };
     }
 

--- a/src/main/java/com/tasty/masiottae/menu/repository/MenuRepositoryImpl.java
+++ b/src/main/java/com/tasty/masiottae/menu/repository/MenuRepositoryImpl.java
@@ -33,27 +33,36 @@ public class MenuRepositoryImpl implements MenuRepositoryCustom {
                 .fetch();
     }
 
-    private BooleanExpression searchExpression(SearchCond searchCond) {
+    private BooleanExpression[] searchExpression(SearchCond searchCond) {
         return switch (searchCond.searchType()) {
             case ALL_MENU -> allSearchCond(searchCond);
-            case LIKE_MENU -> likeSearchCond(searchCond);
-            case MY_MENU -> mySearchCond(searchCond);
+            case LIKE_MENU -> mySearchCond(searchCond);
+            case MY_MENU -> likeSearchCond(searchCond);
         };
     }
 
-    private BooleanExpression allSearchCond(SearchCond searchCond) {
-        return containKeyword(searchCond.keyword()).and(tasteIn(searchCond.tastes()))
-                .and(franchiseEq(searchCond.franchise()));
+    private BooleanExpression[] allSearchCond(SearchCond searchCond) {
+        return new BooleanExpression[]{
+                containKeyword(searchCond.keyword()),
+                tasteIn(searchCond.tastes()),
+                franchiseEq(searchCond.franchise())
+        };
     }
 
-    private BooleanExpression mySearchCond(SearchCond searchCond) {
-        return containKeyword(searchCond.keyword()).and(tasteIn(searchCond.tastes()))
-                .and(accountEq(searchCond.account()));
+    private BooleanExpression[] mySearchCond(SearchCond searchCond) {
+        return new BooleanExpression[]{
+                containKeyword(searchCond.keyword()),
+                tasteIn(searchCond.tastes()),
+                accountEq(searchCond.account())
+        };
     }
 
-    private BooleanExpression likeSearchCond(SearchCond searchCond) {
-        return containKeyword(searchCond.keyword()).and(tasteIn(searchCond.tastes()))
-                .and(likeMenuAccountContain(searchCond.account()));
+    private BooleanExpression[] likeSearchCond(SearchCond searchCond) {
+        return new BooleanExpression[]{
+                containKeyword(searchCond.keyword()),
+                tasteIn(searchCond.tastes()),
+                likeMenuAccountContain(searchCond.account())
+        };
     }
 
     private BooleanExpression likeMenuAccountContain(Account account) {


### PR DESCRIPTION
## 개요
- 메뉴 검색 API에서 keyword 파라미터를 전달하지 않을시 500 응답이 발생하는 버그를 수정

## 변경사항(Optional)
### 변경 전
기존 Querydsl where 조건들을 and()로 체이닝하여 사용. -> 조건 중 null이 있는 경우 NullPointerException이 발생
### 변경 후
where 절 조건들을 and로 체이닝 하는 것이 아닌 , 로 구분한 여러 개의 인자로 전달