### PR TITLE
[#181] 검색 API 버그 수정

### DIFF
--- a/src/main/java/com/tasty/masiottae/menu/service/MenuService.java
+++ b/src/main/java/com/tasty/masiottae/menu/service/MenuService.java
@@ -31,6 +31,7 @@ import com.tasty.masiottae.menu.enums.MenuSortCond;
 import com.tasty.masiottae.menu.enums.SearchType;
 import com.tasty.masiottae.menu.repository.MenuRepository;
 import com.tasty.masiottae.menu.repository.MenuTasteRepository;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -182,11 +183,19 @@ public class MenuService {
                             .containsAll(tastes)).toList();
         }
 
+        if (isNotFoundMenuForCondition(menus)) {
+            return new SearchMenuResponse(Collections.emptyList(), true);
+        }
+
         PageResponse<Menu> pageResponse = PageUtil.page(menus, size, page);
 
         return new SearchMenuResponse(
                 menuConverter.toMenuFindResponseList(pageResponse.list()),
                 pageResponse.isLast());
+    }
+
+    private boolean isNotFoundMenuForCondition(List<Menu> menus) {
+        return menus.isEmpty();
     }
 
     private void validateFranchiseIdIsNotNull(Long franchiseId) {

--- a/src/test/java/com/tasty/masiottae/menu/service/MenuServiceTest.java
+++ b/src/test/java/com/tasty/masiottae/menu/service/MenuServiceTest.java
@@ -408,6 +408,7 @@ class MenuServiceTest {
     @DisplayName("좋아요한 메뉴 검색시 전체 페이지 수보다 큰 페이지 번호를 전달하면 예외가 발생한다.")
     void searchLikeMenuFailByOffsetTest() {
         // Given
+        account.getLikeMenuList().add(new LikeMenu(account, findMenu));
         MyInfoSearchMenuRequest request = new MyInfoSearchMenuRequest(account.getId(),
                 Integer.MAX_VALUE, 10, "이름", "recent",
                 tastes.stream().map(Taste::getId).toList());


### PR DESCRIPTION
## 개요
검색 API 호출시 검색 조건에 이상은 없으나 검색 결과가 없는 경우 빈 리스트가 응답 되는 것이 아닌 에러 응답이 발생하는 것을 수정

## 변경사항
- 검색 조건에 이상은 없으나 검색 결과가 없는 경우 빈 리스트가 응답되도록 수정